### PR TITLE
Fixes White out glitch on binded dms skins

### DIFF
--- a/CustomSlugcatUtils/Hooks/PlayerGraphicsHooks.cs
+++ b/CustomSlugcatUtils/Hooks/PlayerGraphicsHooks.cs
@@ -139,7 +139,6 @@ namespace CustomSlugcatUtils.Hooks
 
                 if (i == 11 && !str.StartsWith("pixel"))
                     sprite.scale = 1;
-                sprite.color = Color.white;
                 if (str.StartsWith("PlayerArm") ||
                     str.StartsWith("Face") ||
                     str.StartsWith("Head") ||


### PR DESCRIPTION
Tested locally via il editing as well as a seperate ilhooking dll, this removes the glitch where binded skins will show up as pitch white. Im not entirely sure why or how it works, but it does, though I request someone tests it with another customutils slugcat other than my own with a binded skin since I wasnt able to find any. 

And yeah it was as simple as just removing that one line of code lol.